### PR TITLE
fix: 修复无法使用通知事件发送消息的问题

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nonebot-adapter-yunhu"
-version = "0.0.6"
+version = "0.0.7"
 description = "A NoneBot adapter for YunHu"
 authors = ["molanp <molanpp@outlook.com>"]
 license = "MIT"

--- a/src/nonebot/adapters/yunhu/bot.py
+++ b/src/nonebot/adapters/yunhu/bot.py
@@ -29,6 +29,7 @@ from .event import (
     InstructionMessageEvent,
     MessageEvent,
     PrivateMessageEvent,
+    NoticeEvent,
 )
 from .message import At, File, Image, Message, MessageSegment, Video
 
@@ -150,6 +151,13 @@ async def send(
             receive_type = "user"
         else:
             receive_id = event.event.message.chatId
+    elif isinstance(event, NoticeEvent):
+        receive_type = event.event.chatType
+        if receive_type == "bot":
+            receive_id = event.get_user_id()
+            receive_type = "user"
+        else:
+            receive_id = event.event.chatId
     else:
         raise ValueError("Cannot guess `receive_id` and `receive_type` to reply!")
 

--- a/src/nonebot/adapters/yunhu/event.py
+++ b/src/nonebot/adapters/yunhu/event.py
@@ -190,7 +190,7 @@ class NoticeEvent(Event):
 
     @override
     def get_user_id(self) -> str:
-        raise ValueError("Event has no user_id!")
+        return self.event.userId
 
     @override
     def get_session_id(self) -> str:


### PR DESCRIPTION
## 由 Sourcery 总结

修复 YunHu 通知事件的处理方式，使得可以对其发送回复消息，并同步更新适配器版本。

Bug 修复：
- 通过从通知事件的负载中正确推导 `receive_id` 和 `receive_type`，允许对 YunHu 通知事件进行回复。
- 为通知事件提供有效的用户 ID，而不是在调用 `get_user_id` 时抛出错误。

构建：
- 将 `nonebot-adapter-yunhu` 包版本更新至 `0.0.7`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix handling of YunHu notice events so messages can be sent in response to them and bump the adapter version.

Bug Fixes:
- Allow replying to YunHu notice events by correctly deriving receive_id and receive_type from the notice event payload.
- Provide a valid user ID for notice events instead of raising an error when get_user_id is called.

Build:
- Bump nonebot-adapter-yunhu package version to 0.0.7.

</details>