### PR TITLE
feat(yunhu): 支持群提示消息事件与消息内容反序列化优化

### DIFF
--- a/src/nonebot/adapters/yunhu/adapter.py
+++ b/src/nonebot/adapters/yunhu/adapter.py
@@ -227,6 +227,8 @@ class Adapter(BaseAdapter):
             event_type = header.get("eventType", "")
             if json_data.get("event", {}).get("message"):
                 event_type += f".{json_data['event']['message']['chatType']}"
+                if json_data["event"]["message"]["contentType"] == "tip":
+                    event_type = "group.tip"
 
             models = cls.get_event_model(event_type)
             for model in models:

--- a/src/nonebot/adapters/yunhu/bot.py
+++ b/src/nonebot/adapters/yunhu/bot.py
@@ -174,7 +174,7 @@ async def send(
             )
             + " "
         )
-        full_message = f"@{event.event.sender.senderNickname}\u200b" + full_message
+        full_message = f"@{event.event.sender.senderNickname}\u200b{full_message}"
     full_message += message
 
     content, msg_type = full_message.serialize()

--- a/src/nonebot/adapters/yunhu/message.py
+++ b/src/nonebot/adapters/yunhu/message.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
 import re
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Optional, TypedDict, Union
 from typing_extensions import override, NotRequired
 
 from nonebot.adapters import Message as BaseMessage
@@ -299,25 +299,14 @@ class Message(BaseMessage[MessageSegment]):
     def deserialize(
         content: Content,
         at_list: Optional[list[str]],
-        message_type: Literal[
-            "text",
-            "image",
-            "markdown",
-            "file",
-            "video",
-            "html",
-            "expression",
-            "form",
-            "tip",
-            "audio",
-        ],
+        message_type: str,
         command_name: Optional[str] = None,
     ) -> "Message":
         command_name = f"{command_name} " if command_name else None
         msg = Message(command_name)
         parsed_content = content.to_dict()
 
-        if message_type in ["text", "markdown", "html"]:
+        if message_type in {"text", "markdown", "html"}:
             assert isinstance(content, Union[TextContent, MarkdownContent, HTMLContent])
             text = content.text
             text_begin = 0
@@ -366,7 +355,6 @@ class Message(BaseMessage[MessageSegment]):
             if matched := text[text_begin:]:
                 msg.append(Text("text", {"text": text[text_begin:]}))
 
-        # 处理其他消息类型
         elif seg_builder := getattr(MessageSegment, message_type, None):
             parsed_content.pop("at", None)
             msg.append(seg_builder(**parsed_content))


### PR DESCRIPTION
- 新增 `TipNoticeEvent` 用于处理云湖群聊中的提示类消息（如“已将"xxx"添加为群管理员”）
- 调整 `Message.deserialize` 方法中对消息类型的判断逻辑，使用集合替代列表提升可读性
- 移除部分冗余的消息类型定义，统一通过字符串匹配处理扩展性更强
- 补充视频、图片等内容的 URL 构建方法并增强模型校验逻辑
- 修复发送消息时 at 用户昵称与消息体之间的空格问题

## Summary by Sourcery

为云湖（Yunhu）群聊“群提示通知”事件提供支持，并简化消息内容处理和 URL 构造逻辑。

新功能：
- 引入 `TipNoticeEvent` 用于表示群提示通知事件，并将接收到的提示类消息映射为此事件类型。

缺陷修复：
- 修复发送消息时，被 @ 的用户名与消息正文之间缺少空格的问题。

增强改进：
- 将 `EventMessage` 的 `contentType` 放宽为通用字符串类型，并简化内容类型的传递与映射逻辑，包括将表情消息视作图片处理。
- 改进 `Message.deserialize` 的分支逻辑，通过基于集合的检查处理类文本消息类型，并对其他消息片段采用通用处理方式。
- 为图片和视频等媒体内容自动填充图片/视频 URL，并明确音频 URL 接口的预期格式。
- 移除未使用的 `ExpressionContent` 和 `TipContent` 模型，改为统一使用基于字符串的内容类型匹配策略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for Yunhu group tip notice events and streamline message content handling and URL construction.

New Features:
- Introduce TipNoticeEvent to represent group tip notifications and map incoming tip messages to this event type.

Bug Fixes:
- Fix missing space placement between the mentioned username and the message body when sending messages.

Enhancements:
- Relax EventMessage contentType to a generic string and simplify content type propagation and mapping, including treating expression messages as images.
- Improve Message.deserialize branching by using a set-based check for text-like message types and generic handling for other message segments.
- Auto-fill image and video URLs for media content and clarify audio URL endpoint expectations.
- Remove unused ExpressionContent and TipContent models in favor of unified string-based content type matching.

</details>