### PR TITLE
feat(yunhu): 添加资源上传功能和消息段优化

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nonebot-adapter-yunhu"
-version = "0.1.3"
+version = "0.1.4"
 description = "A NoneBot adapter for YunHu"
 authors = ["molanp <molanpp@outlook.com>"]
 license = "MIT"
@@ -24,6 +24,7 @@ python = ">=3.9,<4.0"
 nonebot2 = ">=2.3.0"
 typing-extensions = ">=4.3.0"
 pydantic = ">=1.10.0,<3.0.0,!=2.5.0,!=2.5.1"
+filetype = "^1.2.0"
 
 [tool.poetry.urls]
 Homepage = "https://github.com/molanp/nonebot-adapter-yunhu"

--- a/src/nonebot/adapters/yunhu/__init__.py
+++ b/src/nonebot/adapters/yunhu/__init__.py
@@ -1,5 +1,5 @@
 from .bot import Bot as Bot
-from .event import Event as Event
+from .event import Event as Event, MessageEvent as MessageEvent
 from .adapter import Adapter as Adapter
 from .message import Message as Message
 from .message import MessageSegment as MessageSegment

--- a/src/nonebot/adapters/yunhu/adapter.py
+++ b/src/nonebot/adapters/yunhu/adapter.py
@@ -253,8 +253,8 @@ class Adapter(BaseAdapter):
                 try:
                     event = type_validate_python(model, json_data)
                     break
-                except Exception:
-                    logger.warning(f"Unsupported event: {json_data}")
+                except Exception as e:
+                    logger.warning(f"Unsupported event: {json_data}\nError: {type(e)}, {e}")
                     return
             else:
                 event = type_validate_python(Event, json_data)
@@ -263,9 +263,9 @@ class Adapter(BaseAdapter):
 
         except Exception as e:
             logger.error(
-                "<r><bg #f8bbd0>Failed to parse event. "
-                f"Raw: {escape_tag(str(json_data))}</bg #f8bbd0></r>",
-                e,
+                "Failed to parse event.\n"
+                f"Raw: {json_data}\n",
+                f"Error: {type(e)}, {e}"
             )
 
     @classmethod

--- a/src/nonebot/adapters/yunhu/bot.py
+++ b/src/nonebot/adapters/yunhu/bot.py
@@ -51,9 +51,13 @@ async def _check_reply(bot: "Bot", event: "Event"):
 
     if event.event.message.parentId != event.event.message.msgId:
         try:
+            if event.event.message.chatType == "bot":
+                chat_id = event.event.sender.senderId
+            else:
+                chat_id = event.event.message.chatId
             result = await bot.get_msg(
                 event.event.message.parentId,
-                event.event.message.chatId,
+                chat_id,
                 event.event.message.chatType,
             )
             if result.senderId == bot.bot_config.app_id:
@@ -61,7 +65,7 @@ async def _check_reply(bot: "Bot", event: "Event"):
                 event.reply = result
 
         except Exception as e:
-            logger.error(f"Failed to get reply message e:{e}")
+            logger.error(f"Failed to get reply message e: {type(e)}, {e}")
 
 
 def _check_at_me(bot: "Bot", event: "Event"):

--- a/src/nonebot/adapters/yunhu/bot.py
+++ b/src/nonebot/adapters/yunhu/bot.py
@@ -177,7 +177,7 @@ async def send(
         full_message += MessageSegment.at(user_id=event.get_user_id(), name=nickname)
     full_message += message
     # 在序列化消息前完成资源上传
-    full_message = await upload_resource_data(bot, message)
+    full_message = await upload_resource_data(bot, full_message)
     content, msg_type = full_message.serialize()
     if reply_to and isinstance(event, MessageEvent):
         parentId = event.event.message.msgId
@@ -613,7 +613,8 @@ class Bot(BaseBot):
         if isinstance(src, str):
             src = await fetch_bytes(self.adapter, src)
         if isinstance(src, Path):
-            src = open(src, "rb").read()
+            with src.open("rb") as f:
+                src = f.read()
 
         extension = filetype.guess_extension(src) or "dat"
 
@@ -643,7 +644,8 @@ class Bot(BaseBot):
         if isinstance(src, str):
             src = await fetch_bytes(self.adapter, src)
         if isinstance(src, Path):
-            src = open(src, "rb").read()
+            with src.open("rb") as f:
+                src = f.read()
 
         extension = filetype.guess_extension(src) or "mp4"
 
@@ -670,7 +672,8 @@ class Bot(BaseBot):
         if isinstance(src, str):
             src = await fetch_bytes(self.adapter, src)
         if isinstance(src, Path):
-            src = open(src, "rb").read()
+            with src.open("rb") as f:
+                src = f.read()
 
         mime = filetype.guess_mime(src)
 
@@ -692,7 +695,6 @@ class Bot(BaseBot):
         extension = mime.split("/")[1]
         if extension == "jpeg":
             extension = "jpg"
-
 
         images = [("image", src)]
 

--- a/src/nonebot/adapters/yunhu/event.py
+++ b/src/nonebot/adapters/yunhu/event.py
@@ -101,7 +101,7 @@ class MessageEvent(Event):
     def get_event_description(self) -> str:
         return (
             f"Message {self.event.message.msgId} from {self.get_user_id()}"
-            f"@[{self.event.message.chatType}:{self.event.message.chatId}]"
+            f"@[{self.event.message.chatType}:{self.event.sender.senderId}]"
             f" '{escape_tag(str(self.get_message()))}'"
         )
 

--- a/src/nonebot/adapters/yunhu/message.py
+++ b/src/nonebot/adapters/yunhu/message.py
@@ -294,7 +294,7 @@ class Message(BaseMessage[MessageSegment]):
         if not self:
             raise ValueError("Empty message")
 
-        result: dict[str, Any] = {"at": [], "text": ""}
+        result: dict[str, Any] = {"at": []}
 
         # 不支持语音发送
         if "audio" in self:

--- a/src/nonebot/adapters/yunhu/models/common.py
+++ b/src/nonebot/adapters/yunhu/models/common.py
@@ -103,6 +103,13 @@ class VideoContent(CommonContent):
     videoKey: str
     """视频key"""
 
+    if PYDANTIC_V2:
+        model_config = ConfigDict(populate_by_name=True)  # type: ignore
+    else:
+
+        class Config:
+            allow_population_by_field_name = True
+
     @model_validator(mode="before")
     @classmethod
     def _fill_video_url(cls, values: dict[str, Any]) -> dict[str, Any]:
@@ -131,6 +138,13 @@ class FileContent(CommonContent):
     """文件大小 (字节)"""
     fileKey: str
     """文件key"""
+
+    if PYDANTIC_V2:
+        model_config = ConfigDict(populate_by_name=True)  # type: ignore
+    else:
+
+        class Config:
+            allow_population_by_field_name = True
 
     @model_validator(mode="before")
     @classmethod
@@ -173,6 +187,13 @@ class AudioContent(CommonContent):
     """音频地址(直接访问需要Refer:https://myapp.jwznb.com)"""
     duration: int = Field(alias="audioDuration")
     """音频时长,单位秒"""
+
+    if PYDANTIC_V2:
+        model_config = ConfigDict(populate_by_name=True)  # type: ignore
+    else:
+
+        class Config:
+            allow_population_by_field_name = True
 
     @model_validator(mode="before")
     @classmethod

--- a/src/nonebot/adapters/yunhu/tool.py
+++ b/src/nonebot/adapters/yunhu/tool.py
@@ -1,5 +1,8 @@
 import re
+from nonebot.drivers import HTTPClientMixin, Request, Response
+from nonebot.adapters import Adapter
 
+from .exception import ApiNotAvailable, NetworkError
 
 YUNHU_EMOJI_MAP = {
     "[.滑稽]": "🤪",
@@ -120,3 +123,24 @@ YUNHU_EMOJI_MAP = {
 # 按长度降序，防止短 key 优先匹配并截断长 key
 _EMOJI_KEYS = sorted(YUNHU_EMOJI_MAP.keys(), key=len, reverse=True)
 _EMOJI_PATTERN = re.compile("|".join(re.escape(k) for k in _EMOJI_KEYS))
+
+
+async def fetch_bytes(adapter: Adapter, url: str) -> bytes:
+    """下载url资源，返回bytes"""
+    
+    request = Request(
+        method="GET",
+        url=url,
+    )
+    if not isinstance(adapter.driver, HTTPClientMixin):
+        raise ApiNotAvailable
+    try:
+        response: Response = await adapter.driver.request(request)
+    except Exception as e:
+        raise NetworkError(f"语音 {url} 下载失败: {e}") from e
+    if isinstance(response.content, bytes):
+        return response.content
+    raise ValueError("Response content is not bytes")
+
+
+__all__ = ["_EMOJI_KEYS", "_EMOJI_PATTERN", "fetch_bytes"]

--- a/src/nonebot/adapters/yunhu/tool.py
+++ b/src/nonebot/adapters/yunhu/tool.py
@@ -137,7 +137,7 @@ async def fetch_bytes(adapter: Adapter, url: str) -> bytes:
     try:
         response: Response = await adapter.driver.request(request)
     except Exception as e:
-        raise NetworkError(f"语音 {url} 下载失败: {e}") from e
+        raise NetworkError(f"Fail to fetch bytes: {e}") from e
     if isinstance(response.content, bytes):
         return response.content
     raise ValueError("Response content is not bytes")


### PR DESCRIPTION
- 添加 filetype 依赖用于文件类型检测
- 实现 upload_image/upload_video/upload_file 方法支持 url/bytes/Path
- 重构 upload_resource_data 函数统一处理资源上传逻辑
- 优化消息段序列化支持混合消息类型
- 修改 At 消息段构造方式使用 MessageSegment.at
- 更新模型字段映射使用别名机制
- 添加 fetch_bytes 工具函数用于下载远程资源

## Summary by Sourcery

添加统一的资源上传支持，并改进云呼（YunHu）消息序列化及内容模型。

新特性：
- 引入 `upload_image`、`upload_video` 和 `upload_file` 方法，这些方法接受 URL、字节数据或文件路径，并返回资源 URL 和 key。
- 新增 `fetch_bytes` 辅助函数，通过适配器的 HTTP 客户端下载远程资源。

增强改进：
- 重构 `upload_resource_data`，以处理图片、视频和文件分段，可接收原始数据或 URL，并与新的 `upload_*` API 集成。
- 改进 `MessageSegment` 的构建和序列化，包括统一的 `At` 构造方式，以及对混合文本、emoji 和媒体的更好处理（多图消息支持 Markdown 渲染）。
- 规范消息和事件模型字段，使用基于别名的映射，并为图片、视频、文件和音频内容派生统一的媒体 key/URL。

构建：
- 新增 `filetype` 依赖，并将包版本提升至 `0.1.4`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unified resource upload support and improve YunHu message serialization and content models.

New Features:
- Introduce upload_image, upload_video, and upload_file methods that accept URLs, bytes, or file paths and return both resource URLs and keys.
- Add a fetch_bytes helper to download remote resources via the adapter HTTP client.

Enhancements:
- Refactor upload_resource_data to handle image, video, and file segments with either raw data or URLs and integrate with the new upload_* APIs.
- Improve MessageSegment construction and serialization, including unified At construction and better handling of mixed text, emoji, and media (with markdown rendering for multi-image messages).
- Normalize message and event model fields to use alias-based mappings and derived media keys/URLs for images, videos, files, and audio content.

Build:
- Add filetype dependency and bump package version to 0.1.4.

</details>

新功能：
- 引入 `upload_image`、`upload_video` 和 `upload_file` 方法，可接受 URL、字节数据和文件路径，并返回资源 URL 和资源键。
- 新增 `fetch_bytes` 辅助函数，通过适配器的 HTTP 客户端下载远程资源。

增强改进：
- 重构 `upload_resource_data`，集中处理使用 URL 或原始数据的图片、视频和文件消息段，并与新的 `upload_*` 接口协同工作。
- 改进 `MessageSegment` 序列化，更好地支持文本、提及、表情和图片的混合消息，包括对多图消息的基于 Markdown 的渲染。
- 规范消息段数据字段（如 `url`、`name`、`duration`、`size`），并通过 `MessageSegment.at` 统一 At 消息的构造方式。
- 更新事件/内容模型，使用基于别名的字段映射，并为媒体内容自动推导资源键和完整 URL。

构建：
- 新增 `filetype` 依赖，并将包版本提升至 `0.1.4`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

添加统一的资源上传支持，并改进云呼（YunHu）消息序列化及内容模型。

新特性：
- 引入 `upload_image`、`upload_video` 和 `upload_file` 方法，这些方法接受 URL、字节数据或文件路径，并返回资源 URL 和 key。
- 新增 `fetch_bytes` 辅助函数，通过适配器的 HTTP 客户端下载远程资源。

增强改进：
- 重构 `upload_resource_data`，以处理图片、视频和文件分段，可接收原始数据或 URL，并与新的 `upload_*` API 集成。
- 改进 `MessageSegment` 的构建和序列化，包括统一的 `At` 构造方式，以及对混合文本、emoji 和媒体的更好处理（多图消息支持 Markdown 渲染）。
- 规范消息和事件模型字段，使用基于别名的映射，并为图片、视频、文件和音频内容派生统一的媒体 key/URL。

构建：
- 新增 `filetype` 依赖，并将包版本提升至 `0.1.4`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unified resource upload support and improve YunHu message serialization and content models.

New Features:
- Introduce upload_image, upload_video, and upload_file methods that accept URLs, bytes, or file paths and return both resource URLs and keys.
- Add a fetch_bytes helper to download remote resources via the adapter HTTP client.

Enhancements:
- Refactor upload_resource_data to handle image, video, and file segments with either raw data or URLs and integrate with the new upload_* APIs.
- Improve MessageSegment construction and serialization, including unified At construction and better handling of mixed text, emoji, and media (with markdown rendering for multi-image messages).
- Normalize message and event model fields to use alias-based mappings and derived media keys/URLs for images, videos, files, and audio content.

Build:
- Add filetype dependency and bump package version to 0.1.4.

</details>

</details>